### PR TITLE
fix(ios): multi-frame page loads

### DIFF
--- a/src/ios/CDVInjectView.m
+++ b/src/ios/CDVInjectView.m
@@ -10,6 +10,14 @@
 
 - (void)pageDidLoad:(NSNotification *)event
 {
+    // CDVPageDidLoadNotification is posted by the UIWebView::webViewDidFinishLoad delegate which
+    //    is called for each frame on a page. We should only inject Cordova sources once - when the
+    //    whole page is finished loading.
+    if ([[[event object] valueForKey:@"isLoading"] boolValue]) {
+        NSLog(@"loader waiting for all page frames to load");
+        return;
+    }
+
     NSLog(@"loading cordova sources");
     [self injectJavascriptFile:@"www/cordova"];
     [self injectJavascriptFile:@"www/cordova_plugins"];


### PR DESCRIPTION
The main part of the iOS injection is triggered by listening to the `CDVPageDidLoadNotification` event which is posted by the `UIWebView::webViewDidFinishLoad` delegate. However that delegate is called for each frame on a page. We should only inject Cordova sources once - when the whole page is finished loading.

Currently, a multi-frame page causes a flurry of errors from Cordova for `cordova already defined` and `module ... already defined`, because it is attempting to inject everything multiple times for that page.

---

[UIWebViewDelegate](https://developer.apple.com/documentation/uikit/uiwebviewdelegate/1617969-webviewdidfinishload)
> Sent after a web view finishes loading a frame.

[UIWebView.isLoading](https://developer.apple.com/documentation/uikit/uiwebview/1617978-isloading)
> A Boolean value indicating whether the receiver is done loading content.